### PR TITLE
fix: sanitize default saving filename

### DIFF
--- a/src/electron/rpc/server.ts
+++ b/src/electron/rpc/server.ts
@@ -104,7 +104,10 @@ export class RpcHandler {
 		const defaultFilename =
 			([artist, album, title].filter(Boolean).join(" - ") || "download") +
 			".opus";
-		const defaultOutputPath = path.join(downloadDir, defaultFilename);
+		const defaultOutputPath = path.join(
+			downloadDir,
+			defaultFilename.replace(/[:<>?*|"]/g, "_"),
+		);
 
 		const dialogResult = await dialog.showSaveDialog(this.window, {
 			defaultPath: defaultOutputPath,


### PR DESCRIPTION
When a video title include "/", the save dialog chokes. For example, LOONA 1/3 https://www.youtube.com/watch?v=2_r4kDUzslg :sweat_smile: 